### PR TITLE
fix: add Finalizar Pedido button to cart page

### DIFF
--- a/src/app/[slug]/cart/page.tsx
+++ b/src/app/[slug]/cart/page.tsx
@@ -57,6 +57,13 @@ export default function CartPage() {
             <span>{formatPrice(totalInCents)}</span>
           </div>
 
+          <Link
+            href={`/${slug}/checkout`}
+            className="block w-full py-2 bg-zinc-900 text-white text-center rounded-md mb-3"
+          >
+            Finalizar Pedido
+          </Link>
+
           <button
             onClick={clearCart}
             className="w-full py-2 border border-zinc-900 text-zinc-900 rounded-md mb-4"

--- a/tests/e2e/cart.spec.ts
+++ b/tests/e2e/cart.spec.ts
@@ -302,6 +302,41 @@ test.describe("Shopping Cart", () => {
     await expect(page.getByText("Seu carrinho está vazio.")).toBeVisible();
   });
 
+  test("Finalizar Pedido button navigates to checkout page", async ({
+    page,
+    request,
+  }) => {
+    const restaurant = await createRestaurant(request, "finalize1");
+    const category = await createCategory(request, restaurant.slug, "Lanches", 1);
+    await createItem(request, restaurant.slug, category.id, {
+      name: "X-Tudo",
+      priceInCents: 3000,
+      sortOrder: 1,
+    });
+
+    await page.goto(`/${restaurant.slug}`);
+    await page.getByRole("button", { name: "Adicionar" }).click();
+
+    await page.goto(`/${restaurant.slug}/cart`);
+
+    await page.getByRole("link", { name: "Finalizar Pedido" }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/${restaurant.slug}/checkout$`));
+  });
+
+  test("empty cart does not show Finalizar Pedido button", async ({
+    page,
+    request,
+  }) => {
+    const restaurant = await createRestaurant(request, "finalize2");
+
+    await page.goto(`/${restaurant.slug}/cart`);
+
+    await expect(
+      page.getByRole("link", { name: "Finalizar Pedido" })
+    ).toHaveCount(0);
+  });
+
   test("cart badge link navigates to cart page", async ({ page, request }) => {
     const restaurant = await createRestaurant(request, "navlink1");
     const category = await createCategory(request, restaurant.slug, "Lanches", 1);

--- a/tests/unit/CartPage.test.tsx
+++ b/tests/unit/CartPage.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+const { useCartMock, useParamsMock } = vi.hoisted(() => ({
+  useCartMock: vi.fn(),
+  useParamsMock: vi.fn(),
+}));
+
+vi.mock("@/components/CartProvider", () => ({
+  useCart: useCartMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: useParamsMock,
+}));
+
+import CartPage from "@/app/[slug]/cart/page";
+
+const fakeItems = [
+  { id: "item-1", name: "X-Burguer", priceInCents: 2000, quantity: 2 },
+];
+
+function setupMocks(items = fakeItems) {
+  useParamsMock.mockReturnValue({ slug: "lanche-do-ze" });
+  useCartMock.mockReturnValue({
+    items,
+    totalInCents: items.reduce((a, i) => a + i.priceInCents * i.quantity, 0),
+    updateQuantity: vi.fn(),
+    clearCart: vi.fn(),
+  });
+}
+
+describe("CartPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders Finalizar Pedido link to checkout when cart has items", () => {
+    setupMocks();
+    render(<CartPage />);
+    const link = screen.getByRole("link", { name: /finalizar pedido/i });
+    expect(link).toHaveAttribute("href", "/lanche-do-ze/checkout");
+  });
+
+  it("does not render Finalizar Pedido link when cart is empty", () => {
+    setupMocks([]);
+    render(<CartPage />);
+    expect(
+      screen.queryByRole("link", { name: /finalizar pedido/i })
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Added `Finalizar Pedido` link on `/[slug]/cart` that navigates to `/[slug]/checkout`
- Link only renders when cart has items
- Aligns page with spec in `docs/features.md:131`

## Tests
- New unit test: `tests/unit/CartPage.test.tsx` (2 tests, green)
- New E2E tests in `tests/e2e/cart.spec.ts` (navigation + hidden on empty cart)
- Full vitest baseline: 22 fails → 21 fails (only the new CartPage test flipped; no regressions)

## Test plan
- [ ] CI Quality Gates green
- [ ] Manual smoke on Vercel preview: add item → cart → click Finalizar → lands on checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)