### PR TITLE
fix: allow PIX in MercadoPago checkout preference

### DIFF
--- a/src/lib/mercadopago.ts
+++ b/src/lib/mercadopago.ts
@@ -57,11 +57,7 @@ export async function createOrderPreference(
       auto_return: "approved",
       notification_url: notificationUrl,
       payment_methods: {
-        excluded_payment_types: [
-          { id: "ticket" },
-          { id: "atm" },
-          { id: "bank_transfer" },
-        ],
+        excluded_payment_types: [{ id: "ticket" }, { id: "atm" }],
       },
       metadata: {
         order_id: params.orderId,

--- a/tests/unit/mercadopago.test.ts
+++ b/tests/unit/mercadopago.test.ts
@@ -73,16 +73,16 @@ describe("createOrderPreference", () => {
     expect(items[0].unit_price).toBe(25);
     expect(items[0].quantity).toBe(1);
 
-    // payment_methods must restrict to PIX + Cartão — other methods excluded
+    // payment_methods must allow PIX + Cartão. In MercadoPago Brasil, PIX has
+    // payment_type "bank_transfer", so bank_transfer MUST NOT be excluded.
     const paymentMethods = body.payment_methods as {
       excluded_payment_types: Array<{ id: string }>;
     };
     expect(paymentMethods.excluded_payment_types).toEqual(
-      expect.arrayContaining([
-        { id: "ticket" },
-        { id: "atm" },
-        { id: "bank_transfer" },
-      ])
+      expect.arrayContaining([{ id: "ticket" }, { id: "atm" }])
+    );
+    expect(paymentMethods.excluded_payment_types).not.toEqual(
+      expect.arrayContaining([{ id: "bank_transfer" }])
     );
 
     expect(result.id).toBe("pref_123");


### PR DESCRIPTION
## Summary

- MercadoPago Brasil classifies PIX under `payment_type: "bank_transfer"`. The preference was excluding `bank_transfer` in `excluded_payment_types`, which silently hid PIX from the Checkout Pro UI.
- Removed `bank_transfer` from the exclusion list; `ticket` (boleto) and `atm` remain excluded.
- Updated the unit test to assert `bank_transfer` is **not** excluded (the previous test was enforcing the buggy behavior).

## Root cause

`src/lib/mercadopago.ts` built the preference with:

```ts
excluded_payment_types: [
  { id: "ticket" },
  { id: "atm" },
  { id: "bank_transfer" },  // ← excluded PIX
]
```

Confirmed via MercadoPago docs (MLB): PIX payments have `payment_method: { id: "pix", type: "bank_transfer" }`.

## Test plan

- [x] `vitest run tests/unit/mercadopago.test.ts` passes (4/4)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [ ] Manually verify on staging that the MercadoPago Checkout Pro page shows PIX as an option

🤖 Generated with [Claude Code](https://claude.com/claude-code)