### PR TITLE
feat: contact form page with CSV storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,9 @@ test-results/
 playwright-report/
 coverage/
 
+# Contact form submissions
+form.txt
+form.test.txt
+
 /src/generated/prisma
 .env*.local

--- a/docs/spec/active/2026-04-19-contact-form/ARCHITECTURE.md
+++ b/docs/spec/active/2026-04-19-contact-form/ARCHITECTURE.md
@@ -1,0 +1,139 @@
+---
+document_type: architecture
+project_id: SPEC-2026-04-19-001
+version: 1.0.0
+last_updated: 2026-04-19
+status: draft
+---
+
+# Formulário de Contato - Technical Architecture
+
+## System Overview
+
+Feature simples de formulário com persistência em arquivo. Sem banco de dados, sem autenticação.
+
+```
+┌─────────────────┐     POST      ┌─────────────────┐     append     ┌──────────┐
+│  /contato page  │ ──────────────▶│ /api/contact    │ ───────────────▶│ form.txt │
+│  (React form)   │               │ (Route Handler) │                │ (CSV)    │
+└─────────────────┘               └─────────────────┘                └──────────┘
+        │                                 │
+        │                                 ▼
+        │                         ┌─────────────────┐
+        └─────────────────────────│ JSON response   │
+                                  │ {success: true} │
+                                  └─────────────────┘
+```
+
+## Component Design
+
+### Component 1: ContactPage (`src/app/contato/page.tsx`)
+
+- **Purpose**: Renderizar formulário de captura de leads
+- **Responsibilities**: 
+  - Exibir campos do formulário
+  - Validar email no frontend
+  - Chamar API e mostrar feedback
+- **Technology**: React Server Component + Client Form
+
+### Component 2: ContactForm (`src/components/ContactForm.tsx`)
+
+- **Purpose**: Componente de formulário reutilizável
+- **Responsibilities**:
+  - Gerenciar estado do formulário
+  - Validação inline
+  - Submit handling
+  - Loading/success/error states
+- **Technology**: React Client Component
+
+### Component 3: Contact API Route (`src/app/api/contact/route.ts`)
+
+- **Purpose**: Receber e persistir dados do formulário
+- **Responsibilities**:
+  - Validar payload
+  - Escapar valores CSV
+  - Append ao form.txt
+  - Retornar status
+- **Technology**: Next.js Route Handler
+
+## Data Design
+
+### Data Model
+
+```typescript
+interface ContactFormData {
+  nome: string;
+  email: string;
+  nomeRestaurante: string;
+  endereco: string;
+  pedidosPorDia: string;
+}
+```
+
+### CSV Format
+
+```csv
+nome,email,nomeRestaurante,endereco,pedidosPorDia,timestamp
+João Silva,joao@email.com,Pizzaria do João,Rua A 123,50,2026-04-19T10:30:00Z
+```
+
+### File Location
+
+- Path: `./form.txt` (raiz do projeto)
+- Header escrito na primeira linha se arquivo não existir
+
+## API Design
+
+### POST /api/contact
+
+**Request:**
+```json
+{
+  "nome": "string",
+  "email": "string",
+  "nomeRestaurante": "string",
+  "endereco": "string",
+  "pedidosPorDia": "string"
+}
+```
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "message": "formulário enviado"
+}
+```
+
+**Response (400):**
+```json
+{
+  "success": false,
+  "message": "email inválido"
+}
+```
+
+## Security Considerations
+
+- Input sanitization (escapar CSV)
+- Rate limiting não implementado (v1)
+- Sem dados sensíveis além de email
+
+## File Structure Changes
+
+```
+src/
+├── app/
+│   ├── contato/
+│   │   └── page.tsx          # NEW: página do formulário
+│   ├── api/
+│   │   └── contact/
+│   │       └── route.ts      # NEW: API route
+│   └── page.tsx              # MODIFY: remover ContactSection import
+├── components/
+│   ├── ContactForm.tsx       # NEW: componente do formulário
+│   └── landing/
+│       ├── HeroSection.tsx   # MODIFY: href="#contato" → href="/contato"
+│       └── ContactSection.tsx # DELETE ou ignorar (não mais importado)
+form.txt                       # NEW: arquivo de dados (criado pelo API)
+```

--- a/docs/spec/active/2026-04-19-contact-form/CHANGELOG.md
+++ b/docs/spec/active/2026-04-19-contact-form/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [1.0.0] - 2026-04-19
+
+### Added
+
+- Complete requirements specification (REQUIREMENTS.md)
+- Technical architecture design (ARCHITECTURE.md)
+- Implementation plan with 7 tasks across 3 phases (IMPLEMENTATION_PLAN.md)
+- Architecture Decision Records (DECISIONS.md)
+
+### Decisions Made
+
+- CSV format for form.txt (user preference)
+- Remove ContactSection from homepage (consolidate to /contato)
+- Email-only validation (minimal friction)

--- a/docs/spec/active/2026-04-19-contact-form/DECISIONS.md
+++ b/docs/spec/active/2026-04-19-contact-form/DECISIONS.md
@@ -1,0 +1,97 @@
+---
+document_type: decisions
+project_id: SPEC-2026-04-19-001
+---
+
+# Formulário de Contato - Architecture Decision Records
+
+## ADR-001: Persistência em Arquivo CSV
+
+**Date**: 2026-04-19
+**Status**: Accepted
+**Deciders**: User
+
+### Context
+
+Precisamos armazenar os dados do formulário de contato. Opções consideradas:
+- Banco de dados (Prisma/PostgreSQL existente)
+- Arquivo JSON
+- Arquivo CSV
+- Serviço externo (Google Sheets, Airtable)
+
+### Decision
+
+Usar arquivo CSV (`form.txt`) na raiz do projeto.
+
+### Consequences
+
+**Positive:**
+- Simples de implementar
+- Fácil de exportar/importar em planilhas
+- Sem dependências adicionais
+- Atende ao requisito explícito do usuário
+
+**Negative:**
+- Sem queries ou buscas
+- Concorrência limitada (acceptable para volume esperado)
+- Perde dados em deploy (pode ser mitigado com volume persistente)
+
+**Neutral:**
+- Precisará de rotação manual se crescer muito
+
+---
+
+## ADR-002: Remover ContactSection em vez de Modificar
+
+**Date**: 2026-04-19
+**Status**: Accepted
+**Deciders**: User
+
+### Context
+
+A homepage tem uma seção ContactSection com mailto. Com a nova página /contato, precisamos decidir o que fazer com ela.
+
+### Decision
+
+Remover completamente a ContactSection da homepage. O arquivo pode ser mantido no repo para histórico.
+
+### Consequences
+
+**Positive:**
+- UX mais limpo (um único ponto de contato)
+- Menos código para manter
+- Força usuários para o formulário rastreável
+
+**Negative:**
+- Perde opção de email direto para quem prefere
+
+---
+
+## ADR-003: Validação Mínima (Email Only)
+
+**Date**: 2026-04-19
+**Status**: Accepted
+**Deciders**: User
+
+### Context
+
+Formulários podem ter validação extensiva ou mínima.
+
+### Decision
+
+Validar apenas formato de email. Demais campos são livres.
+
+### Consequences
+
+**Positive:**
+- UX com menos fricção
+- Implementação mais simples
+
+**Negative:**
+- Pode receber dados incompletos
+- Campo pedidos/dia pode ter valores não numéricos
+
+### Alternatives Considered
+
+1. **Todos os campos obrigatórios**: Rejeitado - mais fricção
+2. **Validação de número para pedidos**: Pode adicionar em v2 se necessário

--- a/docs/spec/active/2026-04-19-contact-form/IMPLEMENTATION_PLAN.md
+++ b/docs/spec/active/2026-04-19-contact-form/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,171 @@
+---
+document_type: implementation_plan
+project_id: SPEC-2026-04-19-001
+version: 1.0.0
+last_updated: 2026-04-19
+status: draft
+estimated_effort: 2-3 horas
+---
+
+# Formulário de Contato - Implementation Plan
+
+## Overview
+
+Implementação TDD de formulário de contato com 7 tarefas em 3 fases.
+
+## Phase Summary
+
+| Phase | Duration | Key Deliverables |
+|-------|----------|------------------|
+| Phase 1: Backend | ~1h | API route + testes |
+| Phase 2: Frontend | ~1h | Página + componente + testes |
+| Phase 3: Integration | ~30min | Atualizar home, remover ContactSection |
+
+---
+
+## Phase 1: Backend (API Route)
+
+**Goal**: API funcional que salva dados em CSV
+
+### Task 1.1: Criar teste da API route
+
+- **Description**: Escrever teste unitário para POST /api/contact
+- **Estimated Effort**: 15 min
+- **Dependencies**: None
+- **Acceptance Criteria**:
+  - [ ] Teste para request válido → 200 + escrita no arquivo
+  - [ ] Teste para email inválido → 400
+  - [ ] Teste de escape CSV (vírgulas, aspas)
+
+### Task 1.2: Implementar API route
+
+- **Description**: Criar `/api/contact/route.ts` que passa os testes
+- **Estimated Effort**: 30 min
+- **Dependencies**: Task 1.1
+- **Acceptance Criteria**:
+  - [ ] Valida campos obrigatórios
+  - [ ] Valida formato de email
+  - [ ] Escapa valores CSV corretamente
+  - [ ] Append ao form.txt com timestamp
+  - [ ] Cria header se arquivo não existe
+  - [ ] Retorna JSON {success, message}
+
+### Phase 1 Deliverables
+
+- [ ] `/api/contact/route.ts` funcional
+- [ ] Testes passando
+- [ ] form.txt criado com header CSV
+
+---
+
+## Phase 2: Frontend (Página e Componente)
+
+**Goal**: Página /contato com formulário funcional
+
+### Task 2.1: Criar teste do componente ContactForm
+
+- **Description**: Teste de renderização e submit do formulário
+- **Estimated Effort**: 15 min
+- **Dependencies**: None
+- **Acceptance Criteria**:
+  - [ ] Renderiza todos os campos
+  - [ ] Submit chama API
+  - [ ] Mostra mensagem de sucesso
+  - [ ] Mostra erro em email inválido
+
+### Task 2.2: Implementar ContactForm
+
+- **Description**: Componente client com formulário
+- **Estimated Effort**: 30 min
+- **Dependencies**: Task 2.1
+- **Acceptance Criteria**:
+  - [ ] Campos: nome, email, nomeRestaurante, endereco, pedidosPorDia
+  - [ ] Validação de email inline
+  - [ ] Loading state no botão
+  - [ ] Success state com mensagem "formulário enviado"
+  - [ ] Error handling
+
+### Task 2.3: Criar página /contato
+
+- **Description**: Page component que usa ContactForm
+- **Estimated Effort**: 15 min
+- **Dependencies**: Task 2.2
+- **Acceptance Criteria**:
+  - [ ] Rota `/contato` acessível
+  - [ ] Layout consistente com landing page
+  - [ ] Título e descrição
+
+### Phase 2 Deliverables
+
+- [ ] `ContactForm.tsx` funcional
+- [ ] `/contato/page.tsx` acessível
+- [ ] Testes passando
+
+---
+
+## Phase 3: Integration
+
+**Goal**: Conectar tudo e limpar código legado
+
+### Task 3.1: Atualizar HeroSection
+
+- **Description**: Mudar href de `#contato` para `/contato`
+- **Estimated Effort**: 5 min
+- **Dependencies**: Phase 2
+- **Acceptance Criteria**:
+  - [ ] Link aponta para /contato
+  - [ ] Teste E2E: click → navega para /contato
+
+### Task 3.2: Remover ContactSection da home
+
+- **Description**: Remover import e uso de ContactSection em page.tsx
+- **Estimated Effort**: 5 min
+- **Dependencies**: Task 3.1
+- **Acceptance Criteria**:
+  - [ ] ContactSection não renderiza na home
+  - [ ] Pode manter arquivo ou deletar (decision: manter para histórico)
+
+### Task 3.3: Teste E2E completo
+
+- **Description**: Fluxo completo: home → click → preencher → enviar → sucesso
+- **Estimated Effort**: 15 min
+- **Dependencies**: Tasks 3.1, 3.2
+- **Acceptance Criteria**:
+  - [ ] Teste Playwright passa
+  - [ ] form.txt contém dados do teste
+
+### Phase 3 Deliverables
+
+- [ ] HeroSection atualizado
+- [ ] ContactSection removido da home
+- [ ] Teste E2E passando
+
+---
+
+## Dependency Graph
+
+```
+Phase 1: Backend
+  Task 1.1 (test) ──▶ Task 1.2 (impl)
+                           │
+                           ▼
+Phase 2: Frontend      (API ready)
+  Task 2.1 (test) ──▶ Task 2.2 (impl) ──▶ Task 2.3 (page)
+                                              │
+                                              ▼
+Phase 3: Integration                    (Page ready)
+  Task 3.1 (hero) ──▶ Task 3.2 (remove) ──▶ Task 3.3 (e2e)
+```
+
+## Testing Checklist
+
+- [ ] Unit tests para API route (validation, CSV escape)
+- [ ] Unit tests para ContactForm (render, submit, states)
+- [ ] E2E test para fluxo completo
+
+## Launch Checklist
+
+- [ ] Todos os testes passando
+- [ ] Build sem erros
+- [ ] form.txt no .gitignore
+- [ ] Manual test no dev server

--- a/docs/spec/active/2026-04-19-contact-form/PROGRESS.md
+++ b/docs/spec/active/2026-04-19-contact-form/PROGRESS.md
@@ -1,0 +1,63 @@
+---
+document_type: progress
+format_version: "1.0.0"
+project_id: SPEC-2026-04-19-001
+project_name: "Formulário de Contato"
+project_status: completed
+current_phase: 3
+implementation_started: 2026-04-19T00:00:00Z
+last_session: 2026-04-19T00:00:00Z
+last_updated: 2026-04-19T00:00:00Z
+---
+
+# Formulário de Contato - Implementation Progress
+
+## Overview
+
+This document tracks implementation progress against the spec plan.
+
+- **Plan Document**: [IMPLEMENTATION_PLAN.md](./IMPLEMENTATION_PLAN.md)
+- **Architecture**: [ARCHITECTURE.md](./ARCHITECTURE.md)
+- **Requirements**: [REQUIREMENTS.md](./REQUIREMENTS.md)
+
+---
+
+## Task Status
+
+| ID | Description | Status | Started | Completed | Notes |
+|----|-------------|--------|---------|-----------|-------|
+| 1.1 | Criar teste da API route | done | 2026-04-19 | 2026-04-19 | 6 testes |
+| 1.2 | Implementar API route | done | 2026-04-19 | 2026-04-19 | CSV escape, validação |
+| 2.1 | Criar teste do componente ContactForm | done | 2026-04-19 | 2026-04-19 | 5 testes |
+| 2.2 | Implementar ContactForm | done | 2026-04-19 | 2026-04-19 | validação, loading state |
+| 2.3 | Criar página /contato | done | 2026-04-19 | 2026-04-19 | |
+| 3.1 | Atualizar HeroSection | done | 2026-04-19 | 2026-04-19 | href → /contato |
+| 3.2 | Remover ContactSection da home | done | 2026-04-19 | 2026-04-19 | |
+| 3.3 | Teste E2E completo | done | 2026-04-19 | 2026-04-19 | 6 testes |
+
+---
+
+## Phase Status
+
+| Phase | Name | Progress | Status |
+|-------|------|----------|--------|
+| 1 | Backend | 100% | done |
+| 2 | Frontend | 100% | done |
+| 3 | Integration | 100% | done |
+
+---
+
+## Divergence Log
+
+| Date | Type | Task ID | Description | Resolution |
+|------|------|---------|-------------|------------|
+
+---
+
+## Session Notes
+
+### 2026-04-19 - Initial Session
+
+- PROGRESS.md initialized from IMPLEMENTATION_PLAN.md
+- 8 tasks identified across 3 phases
+- Ready to begin implementation with Task 1.1 (TDD)

--- a/docs/spec/active/2026-04-19-contact-form/README.md
+++ b/docs/spec/active/2026-04-19-contact-form/README.md
@@ -1,0 +1,43 @@
+---
+project_id: SPEC-2026-04-19-001
+project_name: "Formulário de Contato"
+slug: contact-form
+status: in-review
+created: 2026-04-19T00:00:00Z
+approved: null
+started: null
+completed: null
+expires: 2026-07-19T00:00:00Z
+superseded_by: null
+tags: [contact-form, lead-capture, landing-page]
+stakeholders: []
+worktree:
+  branch: claude/modest-proskuriakova-eb921d
+  base_branch: main
+---
+
+# Formulário de Contato
+
+## Summary
+
+Criar uma página `/contato` com formulário de captura de leads para restaurantes interessados no Cardápio Rápido. O botão "Quero abrir minha loja" na hero section deve redirecionar para esta página em vez do anchor `#contato`.
+
+## Current State
+
+- HeroSection tem link `href="#contato"` (linha 31)
+- ContactSection atual usa mailto para contato@cardapiorapido.com.br
+- Não há página `/contato` dedicada
+
+## Proposed Changes
+
+1. Criar página `/contato` com formulário
+2. Atualizar link na HeroSection de `#contato` para `/contato`
+3. Formulário salva dados em `form.txt` na raiz
+
+## Status
+
+- [x] Project initialized
+- [x] Requirements elicitation
+- [x] Architecture design
+- [x] Implementation plan
+- [ ] Review and approval

--- a/docs/spec/active/2026-04-19-contact-form/REQUIREMENTS.md
+++ b/docs/spec/active/2026-04-19-contact-form/REQUIREMENTS.md
@@ -1,0 +1,117 @@
+---
+document_type: requirements
+project_id: SPEC-2026-04-19-001
+version: 1.0.0
+last_updated: 2026-04-19
+status: draft
+---
+
+# Formulário de Contato - Product Requirements Document
+
+## Executive Summary
+
+Criar uma página `/contato` dedicada para captura de leads de restaurantes interessados no Cardápio Rápido. O formulário coleta informações básicas do estabelecimento e salva em arquivo CSV para processamento posterior. A seção de contato atual na homepage será removida.
+
+## Problem Statement
+
+### The Problem
+
+O fluxo atual de captação de leads usa um link mailto, que é pouco rastreável e depende do cliente ter um email configurado no navegador.
+
+### Impact
+
+Leads potenciais são perdidos quando o mailto não funciona ou quando o usuário abandona antes de enviar o email.
+
+### Current State
+
+- Botão "Quero abrir minha loja" leva para `#contato` (anchor na página)
+- Seção ContactSection mostra link mailto
+- Não há captura estruturada de dados
+
+## Goals and Success Criteria
+
+### Primary Goal
+
+Capturar informações de restaurantes interessados de forma estruturada e confiável.
+
+### Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Taxa de conversão | Maior que mailto | Comparar envios vs visitas |
+| Dados completos | 100% | Validação frontend |
+
+### Non-Goals
+
+- Sistema de CRM ou gestão de leads
+- Envio de emails automáticos
+- Dashboard de análise
+
+## User Analysis
+
+### Primary Users
+
+- **Donos de restaurantes** que querem digitalizar seu cardápio
+- **Gerentes** avaliando soluções de pedidos online
+
+### User Stories
+
+1. Como dono de restaurante, quero preencher um formulário simples para que a equipe do Cardápio Rápido entre em contato comigo.
+2. Como visitante, quero ver uma confirmação clara de que meus dados foram enviados.
+
+## Functional Requirements
+
+### Must Have (P0)
+
+| ID | Requirement | Rationale | Acceptance Criteria |
+|----|-------------|-----------|---------------------|
+| FR-001 | Página /contato com formulário | Core feature | Acessível via URL direta |
+| FR-002 | Campos: nome, email, nome do restaurante, endereço, pedidos/dia | Dados necessários para qualificação | Todos renderizados e funcionais |
+| FR-003 | Salvar em form.txt na raiz (CSV) | Persistência simples | Cada envio = nova linha |
+| FR-004 | Mensagem "formulário enviado" | Feedback ao usuário | Exibida após sucesso |
+| FR-005 | Validação de email | Evitar dados inválidos | Formato válido requerido |
+| FR-006 | Atualizar HeroSection href | Navegação correta | Link aponta para /contato |
+| FR-007 | Remover ContactSection da home | Consolidar em única página | Seção não renderiza |
+
+### Should Have (P1)
+
+| ID | Requirement | Rationale | Acceptance Criteria |
+|----|-------------|-----------|---------------------|
+| FR-101 | Loading state no botão | UX durante envio | Botão desabilitado enquanto salva |
+| FR-102 | Tratamento de erro | Resiliência | Mensagem de erro se falhar |
+
+## Non-Functional Requirements
+
+### Performance
+
+- Tempo de resposta do formulário < 1s
+
+### Security
+
+- Dados salvos no servidor (não expostos no cliente)
+- API route valida input
+
+### Maintainability
+
+- Componente isolado para o formulário
+- Tipos TypeScript para os dados
+
+## Technical Constraints
+
+- Next.js App Router (conforme projeto)
+- TypeScript strict mode
+- Tailwind CSS para estilos
+- Prisma não necessário (arquivo texto)
+
+## Risks and Mitigations
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| Arquivo form.txt cresce muito | Low | Low | Rotacionar periodicamente |
+| Concorrência de escrita | Low | Medium | appendFileSync é atômico o suficiente |
+
+## Open Questions
+
+- [x] Formato do arquivo → CSV
+- [x] O que fazer com ContactSection → Remover
+- [x] Validações → Email obrigatório

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+
+interface ContactFormData {
+  nome: string;
+  email: string;
+  nomeRestaurante: string;
+  endereco: string;
+  pedidosPorDia: string;
+}
+
+const REQUIRED_FIELDS: (keyof ContactFormData)[] = [
+  "nome",
+  "email",
+  "nomeRestaurante",
+  "endereco",
+  "pedidosPorDia",
+];
+
+const CSV_HEADER = "nome,email,nomeRestaurante,endereco,pedidosPorDia,timestamp";
+
+function isValidEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}
+
+function escapeCSV(value: string): string {
+  const needsQuotes = value.includes(",") || value.includes('"') || value.includes("\n");
+  if (needsQuotes) {
+    const escaped = value.replace(/"/g, '""');
+    return `"${escaped}"`;
+  }
+  return value;
+}
+
+function getFormFilePath(): string {
+  return process.env.FORM_FILE_PATH || path.join(process.cwd(), "form.txt");
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const body = await request.json();
+
+    // Validate required fields
+    for (const field of REQUIRED_FIELDS) {
+      if (!body[field] || typeof body[field] !== "string" || body[field].trim() === "") {
+        return NextResponse.json(
+          { success: false, message: `Campo obrigatório ausente: ${field}` },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Validate email format
+    if (!isValidEmail(body.email)) {
+      return NextResponse.json(
+        { success: false, message: "email inválido" },
+        { status: 400 }
+      );
+    }
+
+    const data: ContactFormData = {
+      nome: body.nome.trim(),
+      email: body.email.trim(),
+      nomeRestaurante: body.nomeRestaurante.trim(),
+      endereco: body.endereco.trim(),
+      pedidosPorDia: body.pedidosPorDia.trim(),
+    };
+
+    const filePath = getFormFilePath();
+    const timestamp = new Date().toISOString();
+
+    // Check if file exists and has content
+    const fileExists = fs.existsSync(filePath) && fs.statSync(filePath).size > 0;
+
+    // Build CSV line
+    const csvLine = [
+      escapeCSV(data.nome),
+      escapeCSV(data.email),
+      escapeCSV(data.nomeRestaurante),
+      escapeCSV(data.endereco),
+      escapeCSV(data.pedidosPorDia),
+      timestamp,
+    ].join(",");
+
+    // Write to file
+    if (!fileExists) {
+      fs.writeFileSync(filePath, CSV_HEADER + "\n" + csvLine + "\n", "utf-8");
+    } else {
+      fs.appendFileSync(filePath, csvLine + "\n", "utf-8");
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "formulário enviado",
+    });
+  } catch (error) {
+    console.error("Contact form error:", error);
+    return NextResponse.json(
+      { success: false, message: "Erro interno do servidor" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/contato/page.tsx
+++ b/src/app/contato/page.tsx
@@ -1,0 +1,47 @@
+import ContactForm from "@/components/ContactForm";
+import Link from "next/link";
+
+export const metadata = {
+  title: "Contato | Cardápio Rápido",
+  description: "Entre em contato para ter o Cardápio Rápido na sua loja",
+};
+
+export default function ContatoPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-white to-zinc-50">
+      <div className="mx-auto max-w-2xl px-6 py-16 sm:py-24">
+        <Link
+          href="/"
+          className="mb-8 inline-flex items-center text-sm font-medium text-zinc-600 hover:text-emerald-600"
+        >
+          ← Voltar para o início
+        </Link>
+
+        <div className="text-center">
+          <span className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+            <span
+              aria-hidden="true"
+              className="h-1.5 w-1.5 rounded-full bg-emerald-500"
+            />
+            Fale com a gente
+          </span>
+          <h1 className="mt-6 text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl">
+            Quero Cardápio Rápido na minha loja
+          </h1>
+          <p className="mt-4 text-base text-zinc-600 sm:text-lg">
+            Preencha o formulário abaixo e entraremos em contato com a
+            configuração inicial do seu cardápio digital.
+          </p>
+        </div>
+
+        <div className="mt-10 rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm sm:p-8">
+          <ContactForm />
+        </div>
+
+        <p className="mt-6 text-center text-sm text-zinc-500">
+          Ao enviar, você concorda em receber contato da equipe Cardápio Rápido.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,6 @@ import { HowItWorksSection } from "@/components/landing/HowItWorksSection";
 import { OperatorSection } from "@/components/landing/OperatorSection";
 import { ConsumerSection } from "@/components/landing/ConsumerSection";
 import { PricingSection } from "@/components/landing/PricingSection";
-import { ContactSection } from "@/components/landing/ContactSection";
 
 export default function Home() {
   return (
@@ -13,7 +12,6 @@ export default function Home() {
       <OperatorSection />
       <ConsumerSection />
       <PricingSection />
-      <ContactSection />
       <footer className="border-t border-zinc-200 bg-white px-6 py-8 text-center text-sm text-zinc-500">
         <p>
           &copy; {new Date().getFullYear()} Cardápio Rápido. Todos os direitos

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+
+interface FormData {
+  nome: string;
+  email: string;
+  nomeRestaurante: string;
+  endereco: string;
+  pedidosPorDia: string;
+}
+
+type FormStatus = "idle" | "loading" | "success" | "error";
+
+function isValidEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}
+
+export default function ContactForm() {
+  const [formData, setFormData] = useState<FormData>({
+    nome: "",
+    email: "",
+    nomeRestaurante: "",
+    endereco: "",
+    pedidosPorDia: "",
+  });
+
+  const [status, setStatus] = useState<FormStatus>("idle");
+  const [message, setMessage] = useState<string>("");
+  const [emailError, setEmailError] = useState<string>("");
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+
+    // Clear email error when user types
+    if (name === "email") {
+      setEmailError("");
+    }
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    // Validate email before submitting
+    if (!isValidEmail(formData.email)) {
+      setEmailError("Email inválido");
+      return;
+    }
+
+    setStatus("loading");
+    setMessage("");
+
+    try {
+      const response = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formData),
+      });
+
+      const data = await response.json();
+
+      if (response.ok && data.success) {
+        setStatus("success");
+        setMessage(data.message);
+        // Clear form on success
+        setFormData({
+          nome: "",
+          email: "",
+          nomeRestaurante: "",
+          endereco: "",
+          pedidosPorDia: "",
+        });
+      } else {
+        setStatus("error");
+        setMessage(data.message || "Erro ao enviar formulário");
+      }
+    } catch {
+      setStatus("error");
+      setMessage("Erro ao enviar formulário. Tente novamente.");
+    }
+  };
+
+  const isLoading = status === "loading";
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+      <div>
+        <label
+          htmlFor="nome"
+          className="block text-sm font-medium text-zinc-700"
+        >
+          Nome
+        </label>
+        <input
+          type="text"
+          id="nome"
+          name="nome"
+          value={formData.nome}
+          onChange={handleChange}
+          required
+          className="mt-1 block w-full rounded-lg border border-zinc-300 px-4 py-2 text-zinc-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="email"
+          className="block text-sm font-medium text-zinc-700"
+        >
+          Email
+        </label>
+        <input
+          type="email"
+          id="email"
+          name="email"
+          value={formData.email}
+          onChange={handleChange}
+          required
+          className="mt-1 block w-full rounded-lg border border-zinc-300 px-4 py-2 text-zinc-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        />
+        {emailError && (
+          <p className="mt-1 text-sm text-red-600">{emailError}</p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="nomeRestaurante"
+          className="block text-sm font-medium text-zinc-700"
+        >
+          Nome do Restaurante
+        </label>
+        <input
+          type="text"
+          id="nomeRestaurante"
+          name="nomeRestaurante"
+          value={formData.nomeRestaurante}
+          onChange={handleChange}
+          required
+          className="mt-1 block w-full rounded-lg border border-zinc-300 px-4 py-2 text-zinc-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="endereco"
+          className="block text-sm font-medium text-zinc-700"
+        >
+          Endereço
+        </label>
+        <input
+          type="text"
+          id="endereco"
+          name="endereco"
+          value={formData.endereco}
+          onChange={handleChange}
+          required
+          className="mt-1 block w-full rounded-lg border border-zinc-300 px-4 py-2 text-zinc-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="pedidosPorDia"
+          className="block text-sm font-medium text-zinc-700"
+        >
+          Quantidade de Pedidos por Dia
+        </label>
+        <input
+          type="text"
+          id="pedidosPorDia"
+          name="pedidosPorDia"
+          value={formData.pedidosPorDia}
+          onChange={handleChange}
+          required
+          placeholder="Ex: 50"
+          className="mt-1 block w-full rounded-lg border border-zinc-300 px-4 py-2 text-zinc-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={isLoading}
+        className="w-full rounded-lg bg-emerald-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isLoading ? "Enviando..." : "Enviar"}
+      </button>
+
+      {status === "success" && (
+        <div className="rounded-lg bg-emerald-50 p-4 text-emerald-800">
+          {message}
+        </div>
+      )}
+
+      {status === "error" && (
+        <div className="rounded-lg bg-red-50 p-4 text-red-800">{message}</div>
+      )}
+    </form>
+  );
+}

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -28,7 +28,7 @@ export function HeroSection() {
             Entrar
           </Link>
           <Link
-            href="#contato"
+            href="/contato"
             className="inline-flex w-full items-center justify-center rounded-lg border border-zinc-300 bg-white px-6 py-3 text-base font-semibold text-zinc-900 shadow-sm transition hover:bg-zinc-50 focus:outline-none focus:ring-2 focus:ring-zinc-400 focus:ring-offset-2 sm:w-auto"
           >
             Quero para minha loja

--- a/tests/e2e/contact.spec.ts
+++ b/tests/e2e/contact.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect } from "@playwright/test";
+import fs from "fs";
+import path from "path";
+
+const FORM_FILE = path.join(process.cwd(), "form.txt");
+
+test.describe("Contact form — /contato", () => {
+  test.beforeEach(async () => {
+    // Clean up form.txt before each test
+    if (fs.existsSync(FORM_FILE)) {
+      fs.unlinkSync(FORM_FILE);
+    }
+  });
+
+  test.afterEach(async () => {
+    // Clean up form.txt after each test
+    if (fs.existsSync(FORM_FILE)) {
+      fs.unlinkSync(FORM_FILE);
+    }
+  });
+
+  test("navigates from home to /contato via CTA", async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("link", { name: "Quero para minha loja" }).first().click();
+    await page.waitForURL("**/contato");
+    expect(new URL(page.url()).pathname).toBe("/contato");
+  });
+
+  test("renders contact form with all required fields", async ({ page }) => {
+    await page.goto("/contato");
+
+    await expect(
+      page.getByRole("heading", { name: /Quero Cardápio Rápido/i })
+    ).toBeVisible();
+    await expect(page.getByLabel(/^Nome$/i)).toBeVisible();
+    await expect(page.getByLabel(/Email/i)).toBeVisible();
+    await expect(page.getByLabel(/Nome do Restaurante/i)).toBeVisible();
+    await expect(page.getByLabel(/Endereço/i)).toBeVisible();
+    await expect(page.getByLabel(/Pedidos por Dia/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /Enviar/i })).toBeVisible();
+  });
+
+  test("submits form successfully and shows confirmation", async ({ page }) => {
+    await page.goto("/contato");
+
+    await page.getByLabel(/^Nome$/i).fill("João Silva");
+    await page.getByLabel(/Email/i).fill("joao@test.com");
+    await page.getByLabel(/Nome do Restaurante/i).fill("Pizzaria do João");
+    await page.getByLabel(/Endereço/i).fill("Rua A, 123");
+    await page.getByLabel(/Pedidos por Dia/i).fill("50");
+
+    await page.getByRole("button", { name: /Enviar/i }).click();
+
+    // Wait for success message
+    await expect(page.getByText(/formulário enviado/i)).toBeVisible();
+  });
+
+  test("writes submission data to form.txt", async ({ page }) => {
+    await page.goto("/contato");
+
+    await page.getByLabel(/^Nome$/i).fill("Maria Santos");
+    await page.getByLabel(/Email/i).fill("maria@test.com");
+    await page.getByLabel(/Nome do Restaurante/i).fill("Lanchonete da Maria");
+    await page.getByLabel(/Endereço/i).fill("Rua B, 456");
+    await page.getByLabel(/Pedidos por Dia/i).fill("30");
+
+    await page.getByRole("button", { name: /Enviar/i }).click();
+
+    // Wait for success message to ensure submission completed
+    await expect(page.getByText(/formulário enviado/i)).toBeVisible();
+
+    // Verify file was written
+    expect(fs.existsSync(FORM_FILE)).toBe(true);
+    const content = fs.readFileSync(FORM_FILE, "utf-8");
+    expect(content).toContain("Maria Santos");
+    expect(content).toContain("maria@test.com");
+    expect(content).toContain("Lanchonete da Maria");
+  });
+
+  test("shows validation error for invalid email", async ({ page }) => {
+    await page.goto("/contato");
+
+    await page.getByLabel(/^Nome$/i).fill("João Silva");
+    await page.getByLabel(/Email/i).fill("invalid-email");
+    await page.getByLabel(/Nome do Restaurante/i).fill("Pizzaria do João");
+    await page.getByLabel(/Endereço/i).fill("Rua A, 123");
+    await page.getByLabel(/Pedidos por Dia/i).fill("50");
+
+    await page.getByRole("button", { name: /Enviar/i }).click();
+
+    // Should show email validation error
+    await expect(page.getByText(/email inválido/i)).toBeVisible();
+  });
+
+  test("complete flow: home → contact → submit → success", async ({ page }) => {
+    // Start from home
+    await page.goto("/");
+
+    // Click CTA to go to contact
+    await page.getByRole("link", { name: "Quero para minha loja" }).first().click();
+    await page.waitForURL("**/contato");
+
+    // Fill form
+    await page.getByLabel(/^Nome$/i).fill("Pedro Costa");
+    await page.getByLabel(/Email/i).fill("pedro@test.com");
+    await page.getByLabel(/Nome do Restaurante/i).fill("Bar do Pedro");
+    await page.getByLabel(/Endereço/i).fill("Rua C, 789");
+    await page.getByLabel(/Pedidos por Dia/i).fill("100");
+
+    // Submit
+    await page.getByRole("button", { name: /Enviar/i }).click();
+
+    // Verify success
+    await expect(page.getByText(/formulário enviado/i)).toBeVisible();
+
+    // Verify data was saved
+    expect(fs.existsSync(FORM_FILE)).toBe(true);
+    const content = fs.readFileSync(FORM_FILE, "utf-8");
+    expect(content).toContain("Pedro Costa");
+    expect(content).toContain("pedro@test.com");
+    expect(content).toContain("Bar do Pedro");
+  });
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -39,11 +39,6 @@ test.describe("Landing page — Cardápio Rápido", () => {
     await expect(page.getByRole("heading", { name: "Preço" })).toBeVisible();
   });
 
-  test("renders the 'Contato' section heading", async ({ page }) => {
-    await page.goto("/");
-    await expect(page.getByRole("heading", { name: "Contato" })).toBeVisible();
-  });
-
   test("'Entrar' CTA links to /backoffice/login", async ({ page }) => {
     await page.goto("/");
     const entrar = page.getByRole("link", { name: "Entrar" });
@@ -60,24 +55,22 @@ test.describe("Landing page — Cardápio Rápido", () => {
     expect(new URL(page.url()).pathname).toBe("/backoffice/login");
   });
 
-  test("'Quero para minha loja' CTA in hero links to #contato", async ({
+  test("'Quero para minha loja' CTA in hero links to /contato", async ({
     page,
   }) => {
     await page.goto("/");
     const hero = page.locator("section").first();
     const cta = hero.getByRole("link", { name: "Quero para minha loja" });
     await expect(cta).toBeVisible();
-    await expect(cta).toHaveAttribute("href", "#contato");
+    await expect(cta).toHaveAttribute("href", "/contato");
   });
 
-  test("#contato anchor resolves to the contact section on the page", async ({
+  test("clicking 'Quero para minha loja' navigates to /contato page", async ({
     page,
   }) => {
     await page.goto("/");
-    const contato = page.locator("#contato");
-    await expect(contato).toBeAttached();
-    await expect(
-      contato.getByRole("heading", { name: "Contato" })
-    ).toBeVisible();
+    await page.getByRole("link", { name: "Quero para minha loja" }).first().click();
+    await page.waitForURL("**/contato");
+    expect(new URL(page.url()).pathname).toBe("/contato");
   });
 });

--- a/tests/unit/ContactForm.test.tsx
+++ b/tests/unit/ContactForm.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import ContactForm from "@/components/ContactForm";
+
+describe("ContactForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("renders all required fields", () => {
+    render(<ContactForm />);
+
+    expect(screen.getByLabelText(/^nome$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^email$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/nome do restaurante/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^endereço$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/pedidos por dia/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /enviar/i })).toBeInTheDocument();
+  });
+
+  it("calls API on valid submit and shows success message", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: true, message: "formulário enviado" }),
+    });
+
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText(/^nome$/i), {
+      target: { value: "João Silva" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "joao@email.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/nome do restaurante/i), {
+      target: { value: "Pizzaria do João" },
+    });
+    fireEvent.change(screen.getByLabelText(/endereço/i), {
+      target: { value: "Rua A, 123" },
+    });
+    fireEvent.change(screen.getByLabelText(/pedidos por dia/i), {
+      target: { value: "50" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /enviar/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          nome: "João Silva",
+          email: "joao@email.com",
+          nomeRestaurante: "Pizzaria do João",
+          endereco: "Rua A, 123",
+          pedidosPorDia: "50",
+        }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/formulário enviado/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error on invalid email format", async () => {
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText(/^nome$/i), {
+      target: { value: "João Silva" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "invalid-email" },
+    });
+    fireEvent.change(screen.getByLabelText(/nome do restaurante/i), {
+      target: { value: "Pizzaria do João" },
+    });
+    fireEvent.change(screen.getByLabelText(/endereço/i), {
+      target: { value: "Rua A, 123" },
+    });
+    fireEvent.change(screen.getByLabelText(/pedidos por dia/i), {
+      target: { value: "50" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /enviar/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/email inválido/i)).toBeInTheDocument();
+    });
+
+    // Should not call API with invalid email
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("shows error when API returns error", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ success: false, message: "Erro no servidor" }),
+    });
+
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText(/^nome$/i), {
+      target: { value: "João Silva" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "joao@email.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/nome do restaurante/i), {
+      target: { value: "Pizzaria do João" },
+    });
+    fireEvent.change(screen.getByLabelText(/endereço/i), {
+      target: { value: "Rua A, 123" },
+    });
+    fireEvent.change(screen.getByLabelText(/pedidos por dia/i), {
+      target: { value: "50" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /enviar/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/erro/i)).toBeInTheDocument();
+    });
+  });
+
+  it("disables submit button while loading", async () => {
+    let resolvePromise: (value: unknown) => void;
+    const promise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockReturnValueOnce(promise);
+
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText(/^nome$/i), {
+      target: { value: "João Silva" },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: "joao@email.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/nome do restaurante/i), {
+      target: { value: "Pizzaria do João" },
+    });
+    fireEvent.change(screen.getByLabelText(/endereço/i), {
+      target: { value: "Rua A, 123" },
+    });
+    fireEvent.change(screen.getByLabelText(/pedidos por dia/i), {
+      target: { value: "50" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /enviar/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+
+    // Cleanup: resolve the promise
+    resolvePromise!({
+      ok: true,
+      json: () => Promise.resolve({ success: true, message: "formulário enviado" }),
+    });
+  });
+});

--- a/tests/unit/HeroSection.test.tsx
+++ b/tests/unit/HeroSection.test.tsx
@@ -22,9 +22,9 @@ describe("HeroSection", () => {
     expect(link).toHaveAttribute("href", "/backoffice/login");
   });
 
-  it("renders 'Quero para minha loja' link pointing to #contato", () => {
+  it("renders 'Quero para minha loja' link pointing to /contato", () => {
     render(<HeroSection />);
     const link = screen.getByRole("link", { name: /Quero para minha loja/i });
-    expect(link).toHaveAttribute("href", "#contato");
+    expect(link).toHaveAttribute("href", "/contato");
   });
 });

--- a/tests/unit/HomePage.test.tsx
+++ b/tests/unit/HomePage.test.tsx
@@ -24,13 +24,10 @@ describe("HomePage (landing)", () => {
     expect(link).toHaveAttribute("href", "/backoffice/login");
   });
 
-  it("renders 'Quero para minha loja' CTA pointing to #contato", () => {
+  it("renders 'Quero para minha loja' CTA pointing to /contato", () => {
     render(<HomePage />);
-    const links = screen.getAllByRole("link", { name: /Quero para minha loja/i });
-    const anchorLink = links.find(
-      (el) => el.getAttribute("href") === "#contato"
-    );
-    expect(anchorLink).toBeDefined();
+    const link = screen.getByRole("link", { name: /Quero para minha loja/i });
+    expect(link).toHaveAttribute("href", "/contato");
   });
 
   it("renders 'Como funciona' section with exactly 3 steps", () => {
@@ -75,20 +72,4 @@ describe("HomePage (landing)", () => {
     expect(screen.getAllByText(/Fatura no fim do mês/i).length).toBeGreaterThan(0);
   });
 
-  it("renders the 'Contato' section heading with id='contato' anchor", () => {
-    render(<HomePage />);
-    const heading = screen.getByRole("heading", { level: 2, name: /Contato/i });
-    expect(heading).toBeInTheDocument();
-    const section = heading.closest("section");
-    expect(section).not.toBeNull();
-    expect(section?.getAttribute("id")).toBe("contato");
-  });
-
-  it("renders a contact mailto link", () => {
-    render(<HomePage />);
-    const mailto = screen
-      .getAllByRole("link")
-      .find((el) => el.getAttribute("href")?.startsWith("mailto:"));
-    expect(mailto).toBeDefined();
-  });
 });

--- a/tests/unit/contact.test.ts
+++ b/tests/unit/contact.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { POST } from "@/app/api/contact/route";
+import { NextRequest } from "next/server";
+import fs from "fs";
+import path from "path";
+
+const TEST_FORM_FILE = path.join(process.cwd(), "form.test.txt");
+
+function createRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost:3000/api/contact", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/contact", () => {
+  beforeEach(() => {
+    // Clean up test file before each test
+    if (fs.existsSync(TEST_FORM_FILE)) {
+      fs.unlinkSync(TEST_FORM_FILE);
+    }
+    // Set test file path via env
+    process.env.FORM_FILE_PATH = TEST_FORM_FILE;
+  });
+
+  afterEach(() => {
+    // Clean up test file after each test
+    if (fs.existsSync(TEST_FORM_FILE)) {
+      fs.unlinkSync(TEST_FORM_FILE);
+    }
+    delete process.env.FORM_FILE_PATH;
+  });
+
+  it("returns 200 and writes to file on valid request", async () => {
+    const request = createRequest({
+      nome: "João Silva",
+      email: "joao@email.com",
+      nomeRestaurante: "Pizzaria do João",
+      endereco: "Rua A, 123",
+      pedidosPorDia: "50",
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      message: "formulário enviado",
+    });
+
+    // Verify file was written
+    expect(fs.existsSync(TEST_FORM_FILE)).toBe(true);
+    const content = fs.readFileSync(TEST_FORM_FILE, "utf-8");
+    expect(content).toContain("João Silva");
+    expect(content).toContain("joao@email.com");
+    expect(content).toContain("Pizzaria do João");
+  });
+
+  it("returns 400 on invalid email", async () => {
+    const request = createRequest({
+      nome: "João Silva",
+      email: "invalid-email",
+      nomeRestaurante: "Pizzaria do João",
+      endereco: "Rua A, 123",
+      pedidosPorDia: "50",
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.message).toContain("email");
+  });
+
+  it("returns 400 when required field is missing", async () => {
+    const request = createRequest({
+      nome: "João Silva",
+      // email missing
+      nomeRestaurante: "Pizzaria do João",
+      endereco: "Rua A, 123",
+      pedidosPorDia: "50",
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  it("escapes CSV special characters correctly", async () => {
+    const request = createRequest({
+      nome: 'João "O Mestre" Silva',
+      email: "joao@email.com",
+      nomeRestaurante: "Pizza, Pasta & More",
+      endereco: "Rua A, 123\nApto 4",
+      pedidosPorDia: "50",
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const content = fs.readFileSync(TEST_FORM_FILE, "utf-8");
+    // CSV escaping: quotes should be doubled, fields with commas/quotes should be quoted
+    expect(content).toContain('"João ""O Mestre"" Silva"');
+    expect(content).toContain('"Pizza, Pasta & More"');
+  });
+
+  it("creates header row if file does not exist", async () => {
+    const request = createRequest({
+      nome: "João Silva",
+      email: "joao@email.com",
+      nomeRestaurante: "Pizzaria do João",
+      endereco: "Rua A, 123",
+      pedidosPorDia: "50",
+    });
+
+    await POST(request);
+
+    const content = fs.readFileSync(TEST_FORM_FILE, "utf-8");
+    const lines = content.trim().split("\n");
+
+    // First line should be header
+    expect(lines[0]).toBe("nome,email,nomeRestaurante,endereco,pedidosPorDia,timestamp");
+    // Second line should be data
+    expect(lines.length).toBe(2);
+  });
+
+  it("appends to existing file without duplicating header", async () => {
+    // First submission
+    await POST(
+      createRequest({
+        nome: "João",
+        email: "joao@email.com",
+        nomeRestaurante: "Pizzaria",
+        endereco: "Rua A",
+        pedidosPorDia: "50",
+      })
+    );
+
+    // Second submission
+    await POST(
+      createRequest({
+        nome: "Maria",
+        email: "maria@email.com",
+        nomeRestaurante: "Lanchonete",
+        endereco: "Rua B",
+        pedidosPorDia: "30",
+      })
+    );
+
+    const content = fs.readFileSync(TEST_FORM_FILE, "utf-8");
+    const lines = content.trim().split("\n");
+
+    // Should have header + 2 data rows
+    expect(lines.length).toBe(3);
+    expect(lines[0]).toContain("nome,email");
+    expect(lines[1]).toContain("João");
+    expect(lines[2]).toContain("Maria");
+  });
+});


### PR DESCRIPTION
## Summary
- New `/contato` page with lead capture form (nome, email, restaurante, endereço, pedidos/dia)
- Hero CTA "Quero para minha loja" now navigates to `/contato` (was `#contato` anchor)
- POST `/api/contact` validates input and appends submissions to `form.txt` at the project root in CSV format
- Removed legacy `ContactSection` from the homepage

## Spec
Full spec under `docs/spec/active/2026-04-19-contact-form/` (SPEC-2026-04-19-001).

## Test plan
- [x] Unit: `tests/unit/contact.test.ts` (6 tests — validation, CSV escape, header, append)
- [x] Unit: `tests/unit/ContactForm.test.tsx` (5 tests — render, submit, errors, loading)
- [x] Unit: `tests/unit/HomePage.test.tsx` + `HeroSection.test.tsx` updated for `/contato`
- [x] E2E: `tests/e2e/contact.spec.ts` (6 tests — navigation, render, submit, file write, validation, full flow)
- [x] `tsc --noEmit` clean
- [x] `npm run build` succeeds (`/contato` prerendered)
- [ ] Manual: open http://localhost:3000, click "Quero para minha loja", submit form, verify `form.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)