### PR TITLE
feat: show time alongside date in orders table

### DIFF
--- a/src/components/OrderTable.tsx
+++ b/src/components/OrderTable.tsx
@@ -90,7 +90,13 @@ export function OrderTable({ orders }: OrderTableProps) {
                     </span>
                   </td>
                   <td className="px-4 py-3 text-gray-600">
-                    {new Date(order.createdAt).toLocaleDateString()}
+                    {new Date(order.createdAt).toLocaleString("pt-BR", {
+                      day: "2-digit",
+                      month: "2-digit",
+                      year: "numeric",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
                   </td>
                 </tr>
                 {isExpanded && (


### PR DESCRIPTION
## Summary
- Updated orders table to display time (HH:MM) alongside the date in the "Data" column
- Format: `DD/MM/YYYY, HH:MM` (pt-BR locale)

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Manual: open `/backoffice/orders`, verify date column shows time

🤖 Generated with [Claude Code](https://claude.com/claude-code)